### PR TITLE
이슈 수정 기능 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,8 +11,9 @@ export function App() {
         <h1 className="mb-4 text-2xl font-bold">📝 GitHub 이슈 목록</h1>
         <Routes>
           <Route path="/" element={<IssueList />} />
-          <Route path="/issues/:issueNumber" element={<IssueList />} />
           <Route path="/issues/new" element={<IssueList />} />
+          <Route path="/issues/:issueNumber" element={<IssueList />} />
+          <Route path="/issues/:issueNumber/edit" element={<IssueList />} />
         </Routes>
       </main>
     </>

--- a/src/api/issueApi.ts
+++ b/src/api/issueApi.ts
@@ -1,4 +1,4 @@
-import { CreateIssueInput } from '@type/githubOctokitTypes';
+import { CreateIssueInput, UpdateIssueInput } from '@type/githubOctokitTypes';
 
 import { githubRepo } from '@/lib/githubRepoInfo';
 import { octokit } from '@/lib/octokit';
@@ -22,5 +22,15 @@ export async function createIssue(input: CreateIssueInput) {
   return octokit.issues.create({
     ...githubRepo,
     ...input,
+  });
+}
+
+export async function updateIssue(input: UpdateIssueInput) {
+  const { issueNumber, ...rest } = input;
+
+  return octokit.issues.update({
+    ...githubRepo,
+    issue_number: issueNumber,
+    ...rest,
   });
 }

--- a/src/components/IssueList.tsx
+++ b/src/components/IssueList.tsx
@@ -1,6 +1,7 @@
 import { getIssues } from '@api/issueApi';
 import { IssueCreateModal } from '@components/issue/IssueCreateModal';
 import { IssueDetailModal } from '@components/issue/IssueDetailModal';
+import { IssueEditModal } from '@components/issue/IssueEditModal';
 import { Skeleton } from '@shared/shadcn/ui/skeleton';
 import { GitHubIssue } from '@type/githubOctokitTypes';
 import { useEffect, useState } from 'react';
@@ -15,6 +16,7 @@ export function IssueList() {
   const navigate = useNavigate();
   const { issueNumber } = useParams<{ issueNumber?: string }>();
   const isCreating = location.pathname === '/issues/new';
+  const isEditing = location.pathname.endsWith('/edit');
 
   const [issues, setIssues] = useState<GitHubIssue[]>([]);
   const [loading, setLoading] = useState(true);
@@ -83,6 +85,20 @@ export function IssueList() {
           onCreated={() => {
             fetchIssues();
             closeModal();
+          }}
+        />
+      )}
+
+      {issueNumber && isEditing && (
+        <IssueEditModal
+          issueNumber={Number(issueNumber)}
+          open={true}
+          onClose={closeModal}
+          onUpdated={() => {
+            setTimeout(() => {
+              fetchIssues();
+              closeModal();
+            }, 2400);
           }}
         />
       )}

--- a/src/components/issue/IssueDetailModal/IssueDetailModal.tsx
+++ b/src/components/issue/IssueDetailModal/IssueDetailModal.tsx
@@ -1,4 +1,4 @@
-import { getIssueDetail } from '@api/issueApi';
+import { getIssueDetail, updateIssue } from '@api/issueApi';
 import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
 import {
   Dialog,
@@ -11,6 +11,9 @@ import { Skeleton } from '@shared/shadcn/ui/skeleton';
 import { formatRelativeTime } from '@shared/utils/date';
 import { GitHubIssueDetail, GitHubLabel } from '@type/githubOctokitTypes';
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { Button } from '@/shared/shadcn/ui/button';
 
 import { IssueAssignees } from './IssueAssignees';
 import { IssueLabels } from './IssueLabels';
@@ -22,7 +25,11 @@ type Props = {
 };
 
 export function IssueDetailModal({ issueNumber, onClose }: Props) {
+  const navigate = useNavigate();
+
   const [issue, setIssue] = useState<GitHubIssueDetail | null>(null);
+  const [closing, setClosing] = useState(false); // 상태 추가
+
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -49,6 +56,25 @@ export function IssueDetailModal({ issueNumber, onClose }: Props) {
 
     fetchDetail();
   }, [issueNumber, onClose]);
+
+  const handleCloseIssue = async () => {
+    if (!issue) return;
+    try {
+      setClosing(true);
+      await updateIssue({
+        issueNumber: issue.number,
+        state: 'closed',
+      });
+      setTimeout(() => {
+        onClose(); // 성공 시 모달 닫기
+      }, 2400);
+    } catch (err) {
+      console.error('이슈를 닫는 데 실패했습니다.', err);
+      alert('이슈를 닫는 데 실패했습니다. 잠시 후 다시 시도해주세요.');
+    } finally {
+      setClosing(false);
+    }
+  };
 
   return (
     <Dialog open={true} onOpenChange={onClose}>
@@ -82,6 +108,23 @@ export function IssueDetailModal({ issueNumber, onClose }: Props) {
 
         {!loading && !error && issue && (
           <>
+            <div className="flex justify-end">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => navigate(`/issues/${issueNumber}/edit`)}
+              >
+                ✏️ 수정
+              </Button>
+              <Button
+                variant="destructive"
+                size="sm"
+                onClick={handleCloseIssue}
+                disabled={closing}
+              >
+                🛑 닫기
+              </Button>
+            </div>
             <div className="my-4 text-sm whitespace-pre-wrap">
               {issue.body ? (
                 issue.body

--- a/src/components/issue/IssueEditModal/IssueEditModal.tsx
+++ b/src/components/issue/IssueEditModal/IssueEditModal.tsx
@@ -1,0 +1,161 @@
+import { updateIssue } from '@api/issueApi';
+import { Button } from '@shared/shadcn/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@shared/shadcn/ui/dialog';
+import { Input } from '@shared/shadcn/ui/input';
+import { Textarea } from '@shared/shadcn/ui/textarea';
+import {
+  GitHubLabel,
+  GitHubUser,
+  UpdateIssueInput,
+} from '@type/githubOctokitTypes';
+import { useEffect, useState } from 'react';
+
+import { getIssueDetail } from '@/api/issueApi';
+import { MultiSelect } from '@/shared/MultiSelect';
+import { fetchMeta } from '@/utils/fetchMeta';
+
+type Props = {
+  issueNumber: number;
+  open: boolean;
+  onClose: () => void;
+  onUpdated?: () => void;
+};
+
+export function IssueEditModal({
+  issueNumber,
+  open,
+  onClose,
+  onUpdated,
+}: Props) {
+  const [title, setTitle] = useState('');
+  const [body, setBody] = useState('');
+  const [labels, setLabels] = useState<GitHubLabel[]>([]);
+  const [users, setUsers] = useState<GitHubUser[]>([]);
+  const [selectedLabels, setSelectedLabels] = useState<string[]>([]);
+  const [selectedAssignees, setSelectedAssignees] = useState<string[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+
+    Promise.all([getIssueDetail(issueNumber), fetchMeta()])
+      .then(([issue, meta]) => {
+        setTitle(issue.title);
+        setBody(issue.body || '');
+
+        setSelectedLabels(
+          issue.labels
+            .map((label) => (typeof label === 'string' ? label : label.name))
+            .filter((name): name is string => !!name)
+        );
+
+        setSelectedAssignees((issue.assignees ?? []).map((user) => user.login));
+
+        setLabels(meta.labels);
+        setUsers(meta.users);
+      })
+      .catch((err) => {
+        console.error('이슈 정보 또는 메타데이터 로딩 실패', err);
+        alert('이슈 정보를 불러오는 데 실패했습니다.');
+        onClose();
+      });
+  }, [open, issueNumber, onClose]);
+
+  const handleSubmit = async () => {
+    if (!title.trim()) return alert('제목을 입력해주세요.');
+    setLoading(true);
+    try {
+      const params: UpdateIssueInput = {
+        issueNumber,
+        title,
+        body,
+        labels: selectedLabels,
+        assignees: selectedAssignees,
+      };
+      await updateIssue(params);
+      onUpdated?.();
+      setTimeout(() => {
+        onClose();
+      }, 2400);
+    } catch (err) {
+      console.error('이슈 수정 실패', err);
+      alert('이슈 수정 중 오류가 발생했습니다.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onClose}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>이슈 수정</DialogTitle>
+          <DialogDescription>
+            제목, 설명, 라벨, 담당자를 수정할 수 있어요.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <Input
+            placeholder="제목"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+          />
+          <Textarea
+            placeholder="설명"
+            value={body}
+            onChange={(e) => setBody(e.target.value)}
+          />
+
+          <div>
+            <h4 className="mb-2 text-sm font-semibold">라벨 선택</h4>
+            <MultiSelect
+              items={labels}
+              selectedItems={selectedLabels}
+              onChange={setSelectedLabels}
+              getKey={(label) => label.name}
+              renderLabel={(label) => (
+                <span
+                  className="rounded px-2 py-0.5"
+                  style={{ backgroundColor: `#${label.color}` }}
+                >
+                  {label.name}
+                </span>
+              )}
+            />
+          </div>
+
+          <div>
+            <h4 className="mb-2 text-sm font-semibold">담당자 선택</h4>
+            <MultiSelect
+              items={users}
+              selectedItems={selectedAssignees}
+              onChange={setSelectedAssignees}
+              getKey={(user) => user.login}
+              renderLabel={(user) => (
+                <>
+                  <img
+                    src={user.avatar_url}
+                    alt={user.login}
+                    className="mr-2 inline-block h-5 w-5 rounded-full"
+                  />
+                  {user.login}
+                </>
+              )}
+            />
+          </div>
+
+          <Button onClick={handleSubmit} disabled={loading}>
+            {loading ? '수정 중...' : '이슈 저장'}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/issue/IssueEditModal/index.ts
+++ b/src/components/issue/IssueEditModal/index.ts
@@ -1,0 +1,1 @@
+export { IssueEditModal } from './IssueEditModal';

--- a/src/types/githubOctokitTypes.ts
+++ b/src/types/githubOctokitTypes.ts
@@ -35,6 +35,9 @@ export type CreateIssueParams =
 export type CreateIssueRequest =
   RestEndpointMethodTypes['issues']['create']['parameters'];
 
+export type UpdateIssueParams =
+  RestEndpointMethodTypes['issues']['update']['parameters'];
+
 //
 // ✍️ 사용자 정의 입력 타입
 //
@@ -44,4 +47,13 @@ export type CreateIssueInput = {
   body?: string;
   labels?: string[];
   assignees?: string[];
+};
+
+export type UpdateIssueInput = {
+  issueNumber: number;
+  title?: string;
+  body?: string;
+  labels?: string[];
+  assignees?: string[];
+  state?: 'open' | 'closed';
 };


### PR DESCRIPTION
## 관련 이슈 번호

Resolves #4 

## 핵심 변경 사항 및 이유

- `IssueEditModal.tsx`를 새로 구현하여, 이슈의 제목, 설명, 라벨, 담당자를 수정할 수 있도록 기능 추가
- `IssueDetailModal` 내 수정 버튼 클릭 시 수정 모달이 열리도록 상태 전환 로직 구현
- 이슈 닫기 기능

## 이외 기타 변경 사항

- 라벨, 담당자 선택 UI 컴포넌트를 재사용하도록 리팩토링
- 수정 완료 시 최신 이슈 정보를 다시 fetch 하도록 로직 보완(버그 있음)

## PR 시 참고 사항

- 라우터 상태와 내부 상태를 조합하여 모달 전환 흐름을 구현했기 때문에, 상세 > 수정 > 리스트로 전환이 자연스럽게 이어지는지 확인 부탁드립니다.
- GitHub API 호출 시 실패할 경우 대비한 에러 핸들링은 기본적인 수준으로만 구현되어 있습니다. 이후 보완이 필요할 수 있습니다.

## 관련 스크린샷

<!-- UI 변경 사항이 있다면 Before/After 스크린샷을 첨부해 주세요. -->

| 이슈 수정| 이슈 상세|
| ------ | ------ |
| ![image](https://github.com/user-attachments/assets/b2279d03-26f2-42f2-bb9a-86895c5a7a7f)| ![image](https://github.com/user-attachments/assets/e8d8bc05-f517-4e9f-8a5b-a7e3e8c4d358)|
